### PR TITLE
Upgrade to crowd 3.3.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM blacklabelops/crowd:3.3.0
+FROM teamatldocker/crowd:3.3.5
+
 
 LABEL maintainer Dwolla Engineering <dev+crowd@dwolla.com>
 LABEL org.label-schema.vcs-url="https://github.com/Dwolla/atlassian-crowd-docker"
@@ -7,7 +8,7 @@ EXPOSE 8443
 
 RUN apk add --upgrade apk-tools && \
     apk add -U jq openssl python py-pip tomcat-native && \
-    curl https://www.digicert.com/CACerts/GTECyberTrustGlobalRoot.crt | openssl x509 -inform der -outform pem -out /usr/local/share/ca-certificates/GTECyberTrustGlobalRoot.crt && \
+    curl https://cacerts.digicert.com/GTECyberTrustGlobalRoot.crt | openssl x509 -inform der -outform pem -out /usr/local/share/ca-certificates/GTECyberTrustGlobalRoot.crt && \
     update-ca-certificates && \
     pip install --upgrade pip && \
     pip install awscli && \

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 Docker image with Atlassian Crowd, running on OpenJDK 8 / Alpine Linux with MySQL drivers.
 
-We use a fork of https://github.com/blacklabelops/crowd as our base image to add specific configurations - mainly enabling SSL on port 8443 and redirecting / to /crowd/ through tomcat.  This docker image builds off that and puts configuration specific data in the correct place to allow for an automated deployment of crowd.
+We use a fork of https://github.com/teamatldocker/crowd as our base image to add specific configurations - mainly enabling SSL on port 8443 and redirecting / to /crowd/ through tomcat.  This docker image builds off that and puts configuration specific data in the correct place to allow for an automated deployment of crowd.
 
 ## Required Environment Variables
 
@@ -25,7 +25,7 @@ Path to an S3 object (e.g. `s3://bucket/object.json`) structured as follows:
 }
 ```
 
-The credentials will be used by the upstream's base image [`launch.sh`](https://github.com/blacklabelops/crowd/blob/master/imagescripts/launch.sh) to create a JNDI resource at `jdbc/CrowdDS`
+The credentials will be used by the upstream's base image [`launch.sh`](https://github.com/teamatldocker/crowd/blob/master/imagescripts/launch.sh) to create a JNDI resource at `jdbc/CrowdDS`
 
 ### `CROWD_CONFIG_OBJECT`
 


### PR DESCRIPTION
Switches github repo names around as needed, and changes the digicert curl since it now responses with a 303, could do a `-L` on the curl, but can just manually follow the redirect:

```
➭ curl https://www.digicert.com/CACerts/GTECyberTrustGlobalRoot.crt
<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
<html><head>
<title>303 See Other</title>
</head><body>
<h1>See Other</h1>
<p>The answer to your request is located <a href="https://cacerts.digicert.com/GTECyberTrustGlobalRoot.crt">here</a>.</p>
</body></html>
```