### PR TITLE
Remove tomcat-native and fix cert path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ LABEL org.label-schema.vcs-url="https://github.com/Dwolla/atlassian-crowd-docker
 EXPOSE 8443
 
 RUN apk add --upgrade apk-tools && \
-    apk add -U jq openssl python py-pip tomcat-native && \
+    apk add -U jq openssl python py-pip && \
     curl https://cacerts.digicert.com/GTECyberTrustGlobalRoot.crt | openssl x509 -inform der -outform pem -out /usr/local/share/ca-certificates/GTECyberTrustGlobalRoot.crt && \
     update-ca-certificates && \
     pip install --upgrade pip && \

--- a/server.xml
+++ b/server.xml
@@ -4,13 +4,34 @@
 
     <Service name="Catalina">
 
-        <Connector URIEncoding="UTF-8" acceptCount="100" compressableMimeType="text/html,text/xml,application/xml,text/plain,text/css,application/json,application/javascript,application/x-javascript" compression="on" connectionTimeout="20000" disableUploadTimeout="true" enableLookups="false" maxHttpHeaderSize="8192" maxThreads="150" minSpareThreads="25" port="8443" sendReasonPhrase="true" useBodyEncodingForURI="true" scheme="https" secure="true" SSLEnabled="true" SSLCertificateFile="conf/localhost-rsa-cert.pem" SSLCertificateKeyFile="conf/localhost-rsa-key.pem" SSLCipherSuite="ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA:ECDHE-RSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-RSA-AES256-SHA256:DHE-RSA-AES256-SHA:ECDHE-ECDSA-DES-CBC3-SHA:ECDHE-RSA-DES-CBC3-SHA:EDH-RSA-DES-CBC3-SHA:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:AES128-SHA:AES256-SHA:DES-CBC3-SHA:!DSS"/>
+        <Connector
+          URIEncoding="UTF-8"
+          acceptCount="100"
+          compressableMimeType="text/html,text/xml,application/xml,text/plain,text/css,application/json,application/javascript,application/x-javascript"
+          compression="on"
+          connectionTimeout="20000"
+          disableUploadTimeout="true"
+          enableLookups="false"
+          maxHttpHeaderSize="8192"
+          maxThreads="150"
+          minSpareThreads="25"
+          port="8443"
+          sendReasonPhrase="true"
+          useBodyEncodingForURI="true"
+          scheme="https" secure="true"
+          SSLEnabled="true"
+          SSLCertificateFile="/opt/crowd/apache-tomcat/conf/localhost-rsa-cert.pem"
+          SSLCertificateKeyFile="/opt/crowd/apache-tomcat/conf/localhost-rsa-key.pem"
+          SSLCipherSuite="ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA:ECDHE-RSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-RSA-AES256-SHA256:DHE-RSA-AES256-SHA:ECDHE-ECDSA-DES-CBC3-SHA:ECDHE-RSA-DES-CBC3-SHA:EDH-RSA-DES-CBC3-SHA:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:AES128-SHA:AES256-SHA:DES-CBC3-SHA:!DSS"
+        />
 
         <Engine defaultHost="localhost" name="Catalina">
             <Host appBase="webapps" autoDeploy="true" name="localhost" unpackWARs="true">
-            <Valve className="org.apache.catalina.valves.AccessLogValve" directory="logs"
-               prefix="localhost_access_log" suffix=".txt"
-               pattern="%h %l %u %t &quot;%r&quot; %s %b" />
+                <Valve className="org.apache.catalina.valves.AccessLogValve"
+                  directory="logs"
+                  prefix="localhost_access_log"
+                  suffix=".txt"
+                  pattern="%h %l %u %t &quot;%r&quot; %s %b" />
             </Host>
         </Engine>
 


### PR DESCRIPTION
Currently, tomcat and tomcat-native cause SSL issues.  As we don't need tomcat-native, we remove it for now until we decide we need to look into performance.

The cert path wasn't being picked up correctly upon removing tomcat, so switched from a relative to full path to resolve that.